### PR TITLE
use load-buffer instead of set-buffer for tmux

### DIFF
--- a/autoload/provider/clipboard.vim
+++ b/autoload/provider/clipboard.vim
@@ -50,7 +50,7 @@ if $DISPLAY != ''
         let s:paste['*'] = 'xsel -o -p'
     endif 
 elseif executable('tmux') && $TMUX != ''
-    let s:copy['+']= 'tmux set-buffer'
+    let s:copy['+']= 'tmux load-buffer -'
     let s:paste['+']= 'tmux paste-buffer'
     let s:copy['*']= s:copy['+']
     let s:paste['*']= s:paste['+']
@@ -60,12 +60,12 @@ else
 endif
 
 if executable('tmux') && $TMUX != ''
-   let s:copy['&']= 'tmux set-buffer'
+   let s:copy['&']= 'tmux load-buffer -'
    let s:paste['&']= 'tmux paste-buffer'
 endif
 
 if executable('tmux') && $TMUX != ''
-   let s:copy['&']= 'tmux set-buffer'
+   let s:copy['&']= 'tmux load-buffer -'
    let s:paste['&']= 'tmux paste-buffer'
 endif
 


### PR DESCRIPTION
Tested in tmux 1.8 and 2.1, set-buffer doesn't work since it only accept data from arguments instead of stdin. This diff uses load-buffer and it works.
